### PR TITLE
fix: update SFML and fix build on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ project(LTheory)
 
 find_package(OpenGL REQUIRED)
 
+find_package(libpng12)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # force SFML to build as a static lib to minimize pain
 set(BUILD_SHARED_LIBS FALSE CACHE BOOL "" FORCE)
 add_subdirectory(ext/SFML)
@@ -185,7 +189,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -g")
 
   # Enable lots of warnings
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wextra")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")

--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eo pipefail
+
+mkdir -p ./build
+pushd ./build
+
+cmake .. -G Ninja
+ninja


### PR DESCRIPTION
Applied changes according to @Rahix discussion:

https://github.com/JoshParnell/ltheory-old/discussions/3

Switched to SFML 2.5.1.

Added a build.bash script.

Note: gentoo required `media-libs/libpng-compat:1.2`